### PR TITLE
Add 8BitDo Ultimate 2 support & dynamic controller mode filtering

### DIFF
--- a/main.py
+++ b/main.py
@@ -130,5 +130,8 @@ class Plugin:
         except Exception as e:
             decky_plugin.logger.error("{__name__} error during migrations {e}")
 
+    async def get_supported_targets(self):
+        return controller_utils.get_supported_target_ids()
+
     async def log_info(self, info):
         decky_plugin.logger.info(info)

--- a/py_modules/controller_utils.py
+++ b/py_modules/controller_utils.py
@@ -11,6 +11,44 @@ import mapping_profiles
 STATE_FILE = "/tmp/.inputplumber.state"
 
 
+def get_supported_target_ids() -> list:
+    """Query InputPlumber Manager for supported target device IDs.
+
+    Returns a list of ID strings (e.g. ["xbox-series", "ds5", ...]),
+    or an empty list if the query fails (older InputPlumber without Manager API).
+    """
+    try:
+        result = subprocess.run(
+            [
+                "busctl", "get-property",
+                "org.shadowblip.InputPlumber",
+                "/org/shadowblip/InputPlumber/Manager",
+                "org.shadowblip.InputManager",
+                "SupportedTargetDeviceIds",
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=get_env(),
+        )
+        if result.returncode != 0:
+            decky_plugin.logger.warning(
+                f"SupportedTargetDeviceIds query failed: {result.stderr.strip()}"
+            )
+            return []
+        # Output format: as <count> "id1" "id2" ...
+        output = result.stdout.strip()
+        if not output.startswith("as "):
+            return []
+        parts = output.split()
+        return [p.strip('"') for p in parts[2:]]
+    except Exception:
+        decky_plugin.logger.warning(
+            "Failed to query SupportedTargetDeviceIds", exc_info=True
+        )
+        return []
+
+
 def clear_state_file():
     """Remove stale state so the next sync re-applies the mode.
 

--- a/src/backend/constants.tsx
+++ b/src/backend/constants.tsx
@@ -4,6 +4,7 @@
 // SteamDeck: deck
 // Xbox: xbox-series
 // Xbox Elite: xbox-elite
+// 8BitDo Ultimate 2: 8bitdo-u2
 
 export enum ControllerModes {
   DEFAULT = "default",
@@ -13,6 +14,7 @@ export enum ControllerModes {
   DUAL_SENSE_EDGE = "ds5-edge",
   HORI_STEAM = "hori-steam",
   STEAM_DECK = "deck-uhid",
+  BITDO_ULTIMATE_2 = "8bitdo-u2",
 }
 
 export enum AdvancedOptionsEnum {

--- a/src/backend/utils.tsx
+++ b/src/backend/utils.tsx
@@ -17,6 +17,7 @@ export enum ServerAPIMethods {
   UPDATE_CUSTOM_PROFILE = "update_custom_profile",
   DELETE_CUSTOM_PROFILE = "delete_custom_profile",
   DUPLICATE_PROFILE = "duplicate_profile",
+  GET_SUPPORTED_TARGETS = "get_supported_targets",
 }
 
 export const onSuspend = (currentGameId: string) => {
@@ -114,3 +115,7 @@ export const duplicateProfile = (sourceId: string, newName: string) => {
     newName
   );
 };
+
+export const getSupportedTargets = callable<[], string[]>(
+  ServerAPIMethods.GET_SUPPORTED_TARGETS
+);

--- a/src/components/controller/ControllerModeDropdown.tsx
+++ b/src/components/controller/ControllerModeDropdown.tsx
@@ -1,11 +1,12 @@
-import { FC } from "react";
+import { FC, useState, useEffect } from "react";
 import { DropdownItem } from "@decky/ui";
 import { useControllerMode } from "../../hooks/controller";
 import { ControllerModes } from "../../backend/constants";
 import { L } from "../../i18n";
 import { t } from "i18next";
+import { getSupportedTargets } from "../../backend/utils";
 
-const MODE_OPTIONS = [
+const ALL_MODE_OPTIONS = [
   { data: ControllerModes.DEFAULT, label: "Default" },
   { data: ControllerModes.XBOX, label: "Xbox Series" },
   { data: ControllerModes.XBOX_ELITE, label: "Xbox Elite" },
@@ -18,12 +19,34 @@ const MODE_OPTIONS = [
 
 const ControllerModeDropdown: FC = () => {
   const [mode, setMode] = useControllerMode();
+  const [supportedIds, setSupportedIds] = useState<string[] | null>(null);
+
+  useEffect(() => {
+    getSupportedTargets()
+      .then((ids) => {
+        if (ids && ids.length > 0) {
+          setSupportedIds(ids);
+        }
+      })
+      .catch(() => {
+        // fallback: show all options
+      });
+  }, []);
+
+  const options =
+    supportedIds === null
+      ? ALL_MODE_OPTIONS
+      : ALL_MODE_OPTIONS.filter(
+          (opt) =>
+            opt.data === ControllerModes.DEFAULT ||
+            supportedIds.includes(opt.data)
+        );
 
   return (
     <DropdownItem
       label={t(L.CONTROLLER_MODE)}
       selectedOption={mode}
-      rgOptions={MODE_OPTIONS}
+      rgOptions={options}
       onChange={(option) => setMode(option.data)}
       bottomSeparator="none"
     />

--- a/src/components/controller/ControllerModeDropdown.tsx
+++ b/src/components/controller/ControllerModeDropdown.tsx
@@ -13,6 +13,7 @@ const MODE_OPTIONS = [
   { data: ControllerModes.DUAL_SENSE_EDGE, label: "DualSense Edge" },
   { data: ControllerModes.HORI_STEAM, label: "Hori Steam" },
   { data: ControllerModes.STEAM_DECK, label: "Steam Deck" },
+  { data: ControllerModes.BITDO_ULTIMATE_2, label: "8BitDo Ultimate 2" },
 ];
 
 const ControllerModeDropdown: FC = () => {


### PR DESCRIPTION
**8BitDo Ultimate 2** (`8bitdo-u2`) mode is added, following InputPlumber support in [ShadowBlip/InputPlumber#544](https://github.com/ShadowBlip/InputPlumber/pull/544).

**Dynamic filtering** — the mode dropdown now queries `SupportedTargetDeviceIds` from InputPlumber's Manager DBus interface and hides targets not supported by the running version. Falls back to showing all options if the query fails (older InputPlumber).